### PR TITLE
Added ability to use new conversation credentials to start session.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -38,17 +38,13 @@ Make sure you're using `node >= 18` so `fetch` is available.
 
 ## Usage
 
-**You need access to Bing Chat OR a valid cookie from someone who has access**.
-**You may also use a Session ID along with a Conversation ID and Signature**. 
+**You need either a valid cookie from Bing Chat, or new conversation credentials**.
 
-The cookie you need from Bing is the `_U` cookie (or just all of the cookies concatenated together; both will work).
-
-If using the two IDs and a Signature parameters set the variable as follows:
+If using a Bing Chat cookie then extract the `_U` cookie and save in the `BING_COOKIE` environment variable, including the `_U=` part. Otherwise, to use the two IDs and a Signature method set the environment variable as follows:
 ```
 BING_COOKIE="{sessionId};{conversationId};{conversationSignature}"
-```
-**These values will need to be updated for each new conversation!**
-
+```  
+**These values will need to be manually updated for each new conversation!**
 
 ```ts
 import { BingChat } from 'bing-chat'

--- a/readme.md
+++ b/readme.md
@@ -39,8 +39,16 @@ Make sure you're using `node >= 18` so `fetch` is available.
 ## Usage
 
 **You need access to Bing Chat OR a valid cookie from someone who has access**.
+**You may also use a Session ID along with a Conversation ID and Signature**. 
 
 The cookie you need from Bing is the `_U` cookie (or just all of the cookies concatenated together; both will work).
+
+If using the two IDs and a Signature parameters set the variable as follows:
+```
+BING_COOKIE="{sessionId};{conversationId};{conversationSignature}"
+```
+**These values will need to be updated for each new conversation!**
+
 
 ```ts
 import { BingChat } from 'bing-chat'

--- a/src/bing-chat.ts
+++ b/src/bing-chat.ts
@@ -17,7 +17,7 @@ export class BingChat {
     /** @defaultValue `false` **/
     debug?: boolean
   }) {
-    const { cookie, clientId, conversationId, conversationSignature, debug = false } = opts
+    const { cookie, debug = false } = opts
 
     this._cookie = cookie
     this._debug = !!debug

--- a/src/bing-chat.ts
+++ b/src/bing-chat.ts
@@ -18,13 +18,13 @@ export class BingChat {
     /** @defaultValue `false` **/
     debug?: boolean
   }) {
-    const { cookie, debug = false } = opts
+    const { cookie, clientId, conversationId, conversationSignature, debug = false } = opts
 
     this._cookie = cookie
     this._debug = !!debug
 
     if (!this._cookie) {
-      throw new Error('Bing cookie is required')
+      throw new Error('Bing cookie or Id/Sig combo is required!')
     }
   }
 
@@ -61,10 +61,17 @@ export class BingChat {
     )
 
     if (isStartOfSession) {
-      const conversation = await this.createConversation()
-      conversationId = conversation.conversationId
-      clientId = conversation.clientId
-      conversationSignature = conversation.conversationSignature
+      if (this._cookie.substring(0,3) === "_U=") {
+        const conversation = await this.createConversation()
+        conversationId = conversation.conversationId
+        clientId = conversation.clientId
+        conversationSignature = conversation.conversationSignature
+      } else {
+        let session = this._cookie.split(";")
+        clientId = session[0]
+        conversationId = session[1]
+        conversationSignature = session[2]
+      }
     }
 
     const result: types.ChatMessage = {


### PR DESCRIPTION
Allows the use of a Client ID, Conversation ID, and Conversation Signature instead of the Bing Chat `_U` cookie to begin a new chat session. This method does require manually updating these values for each new chat session, however.