### PR TITLE
Adds way to get around bing chat limit

### DIFF
--- a/src/bing-chat.ts
+++ b/src/bing-chat.ts
@@ -49,7 +49,8 @@ export class BingChat {
       locale = 'en-US',
       market = 'en-US',
       region = 'US',
-      location
+      location,
+      messageType = 'Chat'
     } = opts
 
     let { conversationId, clientId, conversationSignature } = opts
@@ -172,7 +173,7 @@ export class BingChat {
                     location: locationStr,
                     author: 'user',
                     inputMethod: 'Keyboard',
-                    messageType: 'Chat',
+                    messageType,
                     text
                   },
                   conversationSignature,

--- a/src/bing-chat.ts
+++ b/src/bing-chat.ts
@@ -200,7 +200,9 @@ export class BingChat {
 
             if (message.type === 1) {
               const update = message as types.ChatUpdate
-              const msg = update.arguments[0].messages[0]
+              const msg = update.arguments[0].messages?.[0]
+
+              if (!msg) continue
 
               // console.log('RESPONSE0', JSON.stringify(update, null, 2))
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ export type SendMessageOptions = {
   clientId?: string
   conversationSignature?: string
   invocationId?: string
+  messageType?: string
   locale?: string
   market?: string
   region?: string
@@ -27,6 +28,7 @@ export interface ChatMessage {
   conversationSignature: string
   conversationExpiryTime?: string
   invocationId?: string
+  messageType?: string
 
   detail?: ChatMessageFull | ChatMessagePartial
 }


### PR DESCRIPTION
If you tell bing chat that it is a search query by passing SearchQuery in message type it will let you ask it unlimited messages. I added an optional parameter to change the messageType. Now you can run the following to be able to ask unlimited questions. This is also based on #18.
```js
const res = await api.sendMessage('Write a 500 word essay on frogs.', {messageType: 'SearchQuery'})
``` 